### PR TITLE
Resolve caching issue for Build Monitor

### DIFF
--- a/src/TeamCitySharp.BuildMonitor/Attributes/DisableCaching.cs
+++ b/src/TeamCitySharp.BuildMonitor/Attributes/DisableCaching.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+
+namespace BuildMonitor.Attributes
+{
+    public class DisableCaching : ActionFilterAttribute
+    {
+        public override void OnResultExecuting(ResultExecutingContext filterContext)
+        {
+            filterContext.HttpContext.Response.Cache.SetExpires(DateTime.UtcNow.AddDays(-1));
+            filterContext.HttpContext.Response.Cache.SetValidUntilExpires(false);
+            filterContext.HttpContext.Response.Cache.SetRevalidation(HttpCacheRevalidation.AllCaches);
+            filterContext.HttpContext.Response.Cache.SetCacheability(HttpCacheability.NoCache);
+            filterContext.HttpContext.Response.Cache.SetNoStore();
+
+            base.OnResultExecuting(filterContext);
+        }
+
+    }
+}

--- a/src/TeamCitySharp.BuildMonitor/Content/Site.css
+++ b/src/TeamCitySharp.BuildMonitor/Content/Site.css
@@ -362,7 +362,7 @@ div#title {
     border:solid 2px #FF0000; 
     background-color: #FF0000;
 }
-.undefined
+.undefined, .unknown
 {
     border:solid 2px #FF6600; 
     background-color: #FF6600;

--- a/src/TeamCitySharp.BuildMonitor/Controllers/HomeController.cs
+++ b/src/TeamCitySharp.BuildMonitor/Controllers/HomeController.cs
@@ -4,17 +4,19 @@ using System.Linq;
 using System.Web;
 using System.Web.Mvc;
 using BuildMonitor.Repository;
+using BuildMonitor.Attributes;
 
 namespace BuildMonitor.Controllers
-{
+{   [DisableCaching]
     public class HomeController : Controller
     {
+        [DisableCaching]
         public ActionResult Index()
         {
             return View(); ;
         }
 
-
+        [DisableCaching]
         public JsonResult GetProjects()
         {
             try

--- a/src/TeamCitySharp.BuildMonitor/Repository/BuildMonitorRepository.cs
+++ b/src/TeamCitySharp.BuildMonitor/Repository/BuildMonitorRepository.cs
@@ -87,6 +87,7 @@ namespace BuildMonitor.Repository
                 return projectList
                     .OrderBy(x => x.LastBuildStatus.ToLower().Contains("success") ? 3 : 0)
                     .ThenBy(x => x.LastBuildStatus.ToLower().Contains("undefined") ? 2 : 0)
+                    .ThenBy(x => x.LastBuildStatus.ToLower().Contains("unknown") ? 2 : 0)
                     .ThenBy(x => x.LastBuildStatus.ToLower().Contains("failure") ? 1 : 0)
                     .ToList<ProjectModel>();
             }

--- a/src/TeamCitySharp.BuildMonitor/TeamCitySharp.BuildMonitor.csproj
+++ b/src/TeamCitySharp.BuildMonitor/TeamCitySharp.BuildMonitor.csproj
@@ -59,6 +59,7 @@
     <Reference Include="System.EnterpriseServices" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\DisableCaching.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>

--- a/src/TeamCitySharp.BuildMonitor/Views/Home/Index.cshtml
+++ b/src/TeamCitySharp.BuildMonitor/Views/Home/Index.cshtml
@@ -14,7 +14,6 @@
             this.LastBuildTime = ko.observable();
             this.LastBuildStatus = ko.observable();
             this.LastBuildStatusText = ko.observable();
-            this.TimeOfRequest = ko.observable();
             this.StatusClass = ko.dependentObservable(function () {
 
                 return "projectItem ".concat(String(this.LastBuildStatus()).toLowerCase()).toString();
@@ -45,7 +44,6 @@
                                                             .LastBuildTime(project.LastBuildTime)
                                                             .LastBuildStatus(project.LastBuildStatus)
                                                             .LastBuildStatusText(project.LastBuildStatusText)
-                                                            .TimeOfRequest(project.TimeOfRequest)
                                                               );
 
                             });


### PR DESCRIPTION
Added a new Attribute class and applied to JSON methods to disable client side caching of JSON results.

Amended CSS styling to handle build status of `unknown`
