### PR TITLE
Force Basic Authentication Header

### DIFF
--- a/src/TeamCitySharp/Connection/TeamCityCaller.cs
+++ b/src/TeamCitySharp/Connection/TeamCityCaller.cs
@@ -65,7 +65,7 @@ namespace TeamCitySharp.Connection
             var httpClient = new HttpClient();
             httpClient.Request.Accept = HttpContentTypes.ApplicationJson;
             httpClient.Request.SetBasicAuthentication(userName, password);
-
+            httpClient.Request.ForceBasicAuth = true;
             return httpClient;
         }
     }


### PR DESCRIPTION
Forces TeamCity caller to submit a Basic Authentication header, sometimes EasyHttp will submit a Authentication Negotiate rather than the Basic Auth header. This requires the latest code from EasyHttp.
