### PR TITLE
Add support for the TeamCity 7.0 write API.

### DIFF
--- a/src/TeamCitySharp/DomainEntities/AgentRequirement.cs
+++ b/src/TeamCitySharp/DomainEntities/AgentRequirement.cs
@@ -1,0 +1,16 @@
+namespace TeamCitySharp.DomainEntities
+{
+    public class AgentRequirement
+    {
+        public override string ToString()
+        {
+            return "agent_requirement";
+        }
+
+        public string Id { get; set; }
+
+        public string Type { get; set; }
+
+        public Properties Properties { get; set; }
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/AgentRequirements.cs
+++ b/src/TeamCitySharp/DomainEntities/AgentRequirements.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class AgentRequirements
+    {
+        public override string ToString()
+        {
+            return "agent-requirements";
+        }
+
+        public List<AgentRequirement> AgentRequirement { get; set; }
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/ArtifactDependencies.cs
+++ b/src/TeamCitySharp/DomainEntities/ArtifactDependencies.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class ArtifactDependencies
+    {
+        public override string ToString()
+        {
+            return "artifact-dependencies";
+        }
+
+        public List<ArtifactDependency> ArtifactDependency { get; set; }
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/ArtifactDependency.cs
+++ b/src/TeamCitySharp/DomainEntities/ArtifactDependency.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class ArtifactDependency
+    {
+        public override string ToString()
+        {
+            return "artifact_dependency";
+        }
+
+        public string Id { get; set; }
+
+        public string Type { get; set; }
+
+        public Properties Properties { get; set; }
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/BuildConfig.cs
+++ b/src/TeamCitySharp/DomainEntities/BuildConfig.cs
@@ -16,5 +16,17 @@
         public string WebUrl { get; set; }
 
         public Project Project { get; set; }
+
+        public Parameters Parameters { get; set; }
+
+        public ArtifactDependencies ArtifactDependencies { get; set; }
+
+        public VcsRootEntries VcsRootEntries { get; set; }
+
+        public BuildSteps Steps { get; set; }
+
+        public AgentRequirements AgentRequirements { get; set; }
+
+        public BuildTriggers Triggers { get; set; }
     }
 }

--- a/src/TeamCitySharp/DomainEntities/BuildStep.cs
+++ b/src/TeamCitySharp/DomainEntities/BuildStep.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class BuildStep
+    {
+        public override string ToString()
+        {
+            return "step";
+        }
+
+        public string Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Type { get; set; }
+
+        public string Disabled { get; set; }
+
+        public Properties Properties { get; set; }
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/BuildSteps.cs
+++ b/src/TeamCitySharp/DomainEntities/BuildSteps.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class BuildSteps
+    {
+        public override string ToString()
+        {
+            return "steps";
+        }
+        /// <summary>
+        /// Lists of all the build steps.
+        /// </summary>
+        public List<BuildStep> Step { get; set; }
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/BuildTrigger.cs
+++ b/src/TeamCitySharp/DomainEntities/BuildTrigger.cs
@@ -1,0 +1,16 @@
+namespace TeamCitySharp.DomainEntities
+{
+    public class BuildTrigger
+    {
+        public override string ToString()
+        {
+            return "trigger";
+        }
+
+        public string Id { get; set; }
+
+        public string Type { get; set; }
+
+        public Properties Properties { get; set; }
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/BuildTriggers.cs
+++ b/src/TeamCitySharp/DomainEntities/BuildTriggers.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class BuildTriggers
+    {
+        public override string ToString()
+        {
+            return "triggers";
+        }
+        /// <summary>
+        /// Lists of all the build triggers
+        /// </summary>
+        public List<BuildTrigger> Trigger { get; set; }
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/Parameters.cs
+++ b/src/TeamCitySharp/DomainEntities/Parameters.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class Parameters
+    {
+        public override string ToString()
+        {
+            return "parameters";
+        }
+
+        public List<Property> Property { get; set; } 
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/Project.cs
+++ b/src/TeamCitySharp/DomainEntities/Project.cs
@@ -15,5 +15,7 @@
         public string WebUrl { get; set; }
 
         public BuildTypeWrapper BuildTypes { get; set; }
+
+        public Parameters Parameters { get; set; }
     }
 }

--- a/src/TeamCitySharp/DomainEntities/Properties.cs
+++ b/src/TeamCitySharp/DomainEntities/Properties.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class Properties
+    {
+        public override string ToString()
+        {
+            return "properties";
+        }
+        public List<Property> Property { get; set; }
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/Property.cs
+++ b/src/TeamCitySharp/DomainEntities/Property.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class Property
+    {
+        public override string ToString()
+        {
+            return Name;
+        }
+
+        public string Name { get; set; }
+        public string Value { get; set; }
+    }
+}
+

--- a/src/TeamCitySharp/DomainEntities/VcsRoot.cs
+++ b/src/TeamCitySharp/DomainEntities/VcsRoot.cs
@@ -14,7 +14,9 @@ namespace TeamCitySharp.DomainEntities
 
         public override string ToString()
         {
-            return vcsName;
+            return Name;
         }
+
+        public Properties Properties { get; set; }
     }
 }

--- a/src/TeamCitySharp/DomainEntities/VcsRootEntries.cs
+++ b/src/TeamCitySharp/DomainEntities/VcsRootEntries.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class VcsRootEntries
+    {
+        public override string ToString()
+        {
+            return "vcs-root-entries";
+        }
+
+        public List<VcsRootEntry> VcsRootEntry { get; set; }
+    }
+}

--- a/src/TeamCitySharp/DomainEntities/VcsRootEntry.cs
+++ b/src/TeamCitySharp/DomainEntities/VcsRootEntry.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace TeamCitySharp.DomainEntities
+{
+    public class VcsRootEntry
+    {
+        public override string ToString()
+        {
+            return "vcs-root-entry";
+        }
+
+        public VcsRoot VcsRoot { get; set; }
+
+        public string CheckoutRules { get; set; }
+
+    }    
+    
+}

--- a/src/TeamCitySharp/DomainEntities/VcsRootField.cs
+++ b/src/TeamCitySharp/DomainEntities/VcsRootField.cs
@@ -1,0 +1,9 @@
+﻿namespace TeamCitySharp.DomainEntities
+{
+    public enum VcsRootField
+    {
+        Name, 
+        Shared, 
+        ProjectId
+    }
+}

--- a/src/TeamCitySharp/ITeamCityClient.cs
+++ b/src/TeamCitySharp/ITeamCityClient.cs
@@ -54,5 +54,24 @@ namespace TeamCitySharp
         List<Build> NonSuccessfulBuildsForUser(string userName);
 
         T CallByUrl<T>(string urlPart);
+		Project CreateProject(string projectName);
+        void DeleteProject(string projectName);
+        BuildConfig CreateConfiguration(string projectName, string configurationName);
+        void SetConfigurationSetting(BuildTypeLocator locator, string settingName, string settingValue);
+        VcsRoot AttachVcsRoot(BuildTypeLocator locator, VcsRoot vcsRoot);
+        void SetVcsRootField(VcsRoot vcsRoot, VcsRootField field, object value);
+        void PostRawArtifactDependency(BuildTypeLocator locator, string rawXml);
+        void PostRawBuildStep(BuildTypeLocator locator, string rawXml);
+        void PostRawBuildTrigger(BuildTypeLocator locator, string rawXml);
+        void SetProjectParameter(string projectName, string settingName, string settingValue);
+        void SetConfigurationParameter(BuildTypeLocator locator, string key, string value);
+        void PostRawAgentRequirement(BuildTypeLocator locator, string rawXml);
+        void DetachVcsRoot(BuildTypeLocator locator, string vcsRootId);
+        void DeleteBuildStep(BuildTypeLocator locator, string buildStepId);
+        void DeleteArtifactDependency(BuildTypeLocator locator, string artifactDependencyId);
+        void DeleteAgentRequirement(BuildTypeLocator locator, string agentRequirementId);
+        void DeleteParameter(BuildTypeLocator locator, string parameterName);
+        void DeleteProjectParameter(string projectName, string parameterName);
+        void DeleteBuildTrigger(BuildTypeLocator locator, string buildTriggerId);
     }
 }

--- a/src/TeamCitySharp/TeamCityClient.cs
+++ b/src/TeamCitySharp/TeamCityClient.cs
@@ -206,14 +206,14 @@ namespace TeamCitySharp
         public List<BuildConfig> BuildConfigsByProjectId(string projectId)
         {
             var buildWrapper = _caller.GetFormat<BuildTypeWrapper>("/app/rest/projects/id:{0}/buildTypes", projectId);
-
+            if (buildWrapper == null || buildWrapper.BuildType == null) return new List<BuildConfig>();
             return buildWrapper.BuildType;
         }
 
         public List<BuildConfig> BuildConfigsByProjectName(string projectName)
         {
             var buildWrapper = _caller.GetFormat<BuildTypeWrapper>("/app/rest/projects/name:{0}/buildTypes", projectName);
-
+            if (buildWrapper == null || buildWrapper.BuildType == null) return new List<BuildConfig>();
             return buildWrapper.BuildType;
         }
 
@@ -225,6 +225,112 @@ namespace TeamCitySharp
                 return buildWrapper.Build;
             }
             return new List<Build>();
+        }
+
+        public Project CreateProject(string projectName)
+        {
+            return _caller.Post<Project>(projectName, "/app/rest/projects/");
+        }
+
+        public void DeleteProject(string projectName)
+        {
+            _caller.DeleteFormat("/app/rest/projects/name:{0}", projectName);
+        }
+
+        public BuildConfig CreateConfiguration(string projectName, string configurationName)
+        {
+            return _caller.PostFormat<BuildConfig>(configurationName, "/app/rest/projects/name:{0}/buildTypes", projectName);
+        }
+
+        public void SetConfigurationSetting(BuildTypeLocator locator, string settingName, string settingValue)
+        {
+            _caller.PutFormat(settingValue, "/app/rest/buildTypes/{0}/settings/{1}", locator, settingName);
+        }
+
+        public VcsRoot AttachVcsRoot(BuildTypeLocator locator, VcsRoot vcsRoot)
+        {
+            string xml = string.Format(@"<vcs-root-entry><vcs-root id=""{0}""/></vcs-root-entry>", vcsRoot.Id);
+            return _caller.PostFormat<VcsRoot>(xml, "/app/rest/buildTypes/{0}/vcs-root-entries", locator);
+        }
+
+        public void SetVcsRootField(VcsRoot vcsRoot, VcsRootField field, object value)
+        {
+            _caller.PutFormat(value, "/app/rest/vcs-roots/id:{0}/{1}", vcsRoot.Id, ToCamelCase(field.ToString()));   
+        }
+
+        public void PostRawArtifactDependency(BuildTypeLocator locator, string rawXml)
+        {
+            _caller.PostFormat<ArtifactDependency>(rawXml, "/app/rest/buildTypes/{0}/artifact-dependencies", locator);    
+        }
+
+        public void PostRawBuildStep(BuildTypeLocator locator, string rawXml)
+        {
+            _caller.PostFormat<BuildConfig>(rawXml, "/app/rest/buildTypes/{0}/steps", locator);
+        }
+
+        public void PostRawBuildTrigger(BuildTypeLocator locator, string rawXml)
+        {
+            _caller.PostFormat(rawXml, "/app/rest/buildTypes/{0}/triggers", locator);
+        }
+
+        public void SetProjectParameter(string projectName, string settingName, string settingValue)
+        {
+            _caller.PutFormat(settingValue, "/app/rest/projects/name:{0}/parameters/{1}", projectName, settingName);
+        }
+
+        public void SetConfigurationParameter(BuildTypeLocator locator, string key, string value)
+        {
+            _caller.PutFormat(value, "/app/rest/buildTypes/{0}/parameters/{1}", locator, key);
+        }
+
+        public void DeleteConfiguration(BuildTypeLocator locator)
+        {
+            _caller.DeleteFormat("/app/rest/buildTypes/{0}", locator);
+        }
+
+        public void PostRawAgentRequirement(BuildTypeLocator locator, string rawXml)
+        {
+            _caller.PostFormat(rawXml, "/app/rest/buildTypes/{0}/agent-requirements", locator);
+        }
+
+        public void DetachVcsRoot(BuildTypeLocator locator, string vcsRootId)
+        {
+            _caller.DeleteFormat("/app/rest/buildTypes/{0}/vcs-root-entries/{1}", locator, vcsRootId);
+        }
+
+        public void DeleteBuildStep(BuildTypeLocator locator, string buildStepId)
+        {
+            _caller.DeleteFormat("/app/rest/buildTypes/{0}/steps/{1}", locator, buildStepId);
+        }
+
+        public void DeleteArtifactDependency(BuildTypeLocator locator, string artifactDependencyId)
+        {
+            _caller.DeleteFormat("/app/rest/buildTypes/{0}/artifact-dependencies/{1}", locator, artifactDependencyId);
+        }
+
+        public void DeleteAgentRequirement(BuildTypeLocator locator, string agentRequirementId)
+        {
+            _caller.DeleteFormat("/app/rest/buildTypes/{0}/agent-requirements/{1}", locator, agentRequirementId);
+        }
+
+        public void DeleteParameter(BuildTypeLocator locator, string parameterName)
+        {
+            _caller.DeleteFormat("/app/rest/buildTypes/{0}/parameters/{1}", locator, parameterName);
+        }
+
+        public void DeleteProjectParameter(string projectName, string parameterName)
+        {
+            _caller.DeleteFormat("/app/rest/projects/name:{0}/parameters/{1}", projectName, parameterName);
+        }
+
+        public void DeleteBuildTrigger(BuildTypeLocator locator, string buildTriggerId)
+        {
+            _caller.DeleteFormat("/app/rest/buildTypes/{0}/triggers/{1}", locator, buildTriggerId);
+        }
+
+        private string ToCamelCase(string s)
+        {
+            return Char.ToLower(s.ToCharArray()[0]) + s.Substring(1);
         }
 
         public Build LastBuildByAgent(string agentName)

--- a/src/TeamCitySharp/TeamCitySharp.csproj
+++ b/src/TeamCitySharp/TeamCitySharp.csproj
@@ -49,6 +49,20 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DomainEntities\AgentRequirement.cs" />
+    <Compile Include="DomainEntities\AgentRequirements.cs" />
+    <Compile Include="DomainEntities\ArtifactDependencies.cs" />
+    <Compile Include="DomainEntities\ArtifactDependency.cs" />
+    <Compile Include="DomainEntities\BuildStep.cs" />
+    <Compile Include="DomainEntities\BuildSteps.cs" />
+    <Compile Include="DomainEntities\BuildTrigger.cs" />
+    <Compile Include="DomainEntities\BuildTriggers.cs" />
+    <Compile Include="DomainEntities\Parameters.cs" />
+    <Compile Include="DomainEntities\Properties.cs" />
+    <Compile Include="DomainEntities\Property.cs" />
+    <Compile Include="DomainEntities\VcsRootEntries.cs" />
+    <Compile Include="DomainEntities\VcsRootEntry.cs" />
+    <Compile Include="DomainEntities\VcsRootField.cs" />
     <Compile Include="Locators\BuildLocator.cs" />
     <Compile Include="Locators\BuildTypeLocator.cs" />
     <Compile Include="Connection\IClientConnection.cs" />


### PR DESCRIPTION
Have been using the basis of your library to successfully batch create build configurations for our project, but had to add support for the new TeamCity 7 write API into the library. 

I have only created the actual calls that I have needed to use for the project so far and still requires some tidy up (i.e currently accepting raw XML for some calls instead of strongly typed objects to serialize). 

Would you be interested in using this as a basis to support writing to TeamCity? 
