### PR TITLE
Added a client method to download the artifacts for a build.

### DIFF
--- a/src/TeamCitySharp/TeamCityClient.cs
+++ b/src/TeamCitySharp/TeamCityClient.cs
@@ -172,6 +172,11 @@ namespace TeamCitySharp
             return build;
         }
 
+        public void DownloadArtifactsByBuildId(string buildId, Action<string> downloadHandler)
+        {
+            _caller.GetDownloadFormat(downloadHandler, "/downloadArtifacts.html?buildId={0}", buildId);
+        }
+
         public BuildConfig BuildConfigByConfigurationId(string buildConfigId)
         {
             var build = _caller.GetFormat<BuildConfig>("/app/rest/buildTypes/id:{0}", buildConfigId);


### PR DESCRIPTION
DownloadArtifactsByBuildId(string buildId, Action<string> downloadHandler)

Executes the handler once the artifact has been downloaded.

Example usage

 var client = new TeamCityClient(url, isUrlSecure);
 client.Connect(username, password);
 client.DownloadArtifactsByBuildId(selected.Id, x => UnZipSomwhere(x));
