### PR TITLE
More artifact related methods.

### DIFF
--- a/src/TeamCitySharp/Connection/TeamCityCaller.cs
+++ b/src/TeamCitySharp/Connection/TeamCityCaller.cs
@@ -110,6 +110,25 @@ namespace TeamCitySharp.Connection
             return response.StaticBody<T>();
         }
 
+        public string GetRaw(string urlPart)
+        {
+            if (CheckForUserNameAndPassword())
+                throw new ArgumentException("If you are not acting as a guest you must supply userName and password");
+
+            if (string.IsNullOrEmpty(urlPart))
+                throw new ArgumentException("Url must be specfied");
+
+            var url = CreateUrl(urlPart);
+
+            var response = CreateHttpRequest(_configuration.UserName, _configuration.Password, HttpContentTypes.TextPlain).Get(url);
+            if (IsHttpError(response))
+            {
+                throw new HttpException(response.StatusCode, string.Format("Error {0}: Thrown with URL {1}", response.StatusDescription, url));
+            }
+
+            return response.RawText;
+        }
+
         private bool CheckForUserNameAndPassword()
         {
             return !_configuration.ActAsGuest && string.IsNullOrEmpty(_configuration.UserName) && string.IsNullOrEmpty(_configuration.Password);


### PR DESCRIPTION
Hi.

I work with a TeamCity instance that publishes a lot of large artifacts, so the existing solution for downloading them wasn't practical for me.

I've added some methods for listing artifacts based on [the patterns in the documentation](http://confluence.jetbrains.net/display/TCD7/Patterns+For+Accessing+Build+Artifacts), and a method for downloading just a single artifact.

This is my first pull request on GitHub so I'm eager to hear what you think. :)
