### PR TITLE
Added pause and unpause build configuration

### DIFF
--- a/src/TeamCitySharp/ActionTypes/BuildConfigs.cs
+++ b/src/TeamCitySharp/ActionTypes/BuildConfigs.cs
@@ -90,6 +90,15 @@ namespace TeamCitySharp.ActionTypes
             _caller.PutFormat(settingValue, HttpContentTypes.TextPlain, "/app/rest/buildTypes/{0}/settings/{1}", locator, settingName);
         }
 
+        public bool GetConfigurationPauseStatus(BuildTypeLocator locator)
+        {
+             return _caller.Get<bool>(string.Format("/app/rest/buildTypes/{0}/paused/", locator.Name));
+        }
+        public void SetConfigurationPauseStatus(BuildTypeLocator locator, bool isPaused)
+        {
+            _caller.PutFormat(isPaused, HttpContentTypes.TextPlain, "/app/rest/buildTypes/{0}/paused/", locator);
+        }
+
         public void PostRawArtifactDependency(BuildTypeLocator locator, string rawXml)
         {
             _caller.PostFormat<ArtifactDependency>(rawXml, HttpContentTypes.ApplicationXml, string.Empty, "/app/rest/buildTypes/{0}/artifact-dependencies", locator);

--- a/src/TeamCitySharp/ActionTypes/IBuildConfigs.cs
+++ b/src/TeamCitySharp/ActionTypes/IBuildConfigs.cs
@@ -20,6 +20,8 @@ namespace TeamCitySharp.ActionTypes
         BuildConfig CreateConfiguration(string projectName, string configurationName);
 
         void SetConfigurationSetting(BuildTypeLocator locator, string settingName, string settingValue);
+        bool GetConfigurationPauseStatus(BuildTypeLocator locator);
+        void SetConfigurationPauseStatus(BuildTypeLocator locator, bool isPaused);
         void PostRawArtifactDependency(BuildTypeLocator locator, string rawXml);
         void PostRawBuildStep(BuildTypeLocator locator, string rawXml);
         void PostRawBuildTrigger(BuildTypeLocator locator, string rawXml);

--- a/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsConfigsUsage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Net;
 using NUnit.Framework;
+using TeamCitySharp.Locators;
 
 namespace TeamCitySharp.IntegrationTests
 {
@@ -64,6 +65,26 @@ namespace TeamCitySharp.IntegrationTests
             var buildConfig = _client.BuildConfigs.ByConfigurationId(buildConfigId);
 
             Assert.That(buildConfig != null, "Cannot find a build type for that buildId");
+        }
+
+        [Test]
+        public void it_pauses_configuration()
+        {
+            string buildConfigId = "bt437";
+            var buildLocator = BuildTypeLocator.WithId(buildConfigId);
+            _client.BuildConfigs.SetConfigurationPauseStatus(buildLocator, true);
+            var status = _client.BuildConfigs.GetConfigurationPauseStatus(buildLocator);
+            Assert.That(status == true, "Build not paused");
+        }
+
+        [Test]
+        public void it_unpauses_configuration()
+        {
+            string buildConfigId = "bt437";
+            var buildLocator = BuildTypeLocator.WithId(buildConfigId);
+            _client.BuildConfigs.SetConfigurationPauseStatus(buildLocator, false);
+            var status = _client.BuildConfigs.GetConfigurationPauseStatus(buildLocator);
+            Assert.That(status == false, "Build not unpaused");
         }
 
         [Test]


### PR DESCRIPTION
Integration tests included. I tested the integration tests against my local teamcity server. I wasn't able to find a build config on the CodeBetter server that the test user had change access to actually run pause and unpause against. 
