### PR TITLE
Added method to "Check for pending changes"

### DIFF
--- a/src/TeamCitySharp/ActionTypes/Builds.cs
+++ b/src/TeamCitySharp/ActionTypes/Builds.cs
@@ -39,6 +39,11 @@ namespace TeamCitySharp.ActionTypes
             _caller.GetFormat("/action.html?add2Queue={0}", buildConfigId);
         }
 
+        public void CheckForChangesByBuildConfigId(string buildConfigId)
+        {
+            _caller.GetFormat("/action.html?checkForChangesBuildType={0}", buildConfigId);
+        }
+
         public List<Build> SuccessfulBuildsByBuildConfigId(string buildConfigId)
         {
             return ByBuildLocator(BuildLocator.WithDimensions(BuildTypeLocator.WithId(buildConfigId),

--- a/src/TeamCitySharp/ActionTypes/IBuilds.cs
+++ b/src/TeamCitySharp/ActionTypes/IBuilds.cs
@@ -23,5 +23,6 @@ namespace TeamCitySharp.ActionTypes
         List<Build> NonSuccessfulBuildsForUser(string userName);
         Build LastBuildByAgent(string agentName);
         void Add2QueueBuildByBuildConfigId(string buildConfigId);
+        void CheckForChangesByBuildConfigId(string buildConfigId);
     }
 }


### PR DESCRIPTION
This is located under "Projects > [Build Configuration] > Actions > Check for pending changes" in the TeamCity interface.

Prior to TeamCity v. 8.0.5 the action expects an internal TeamCity buildConfigId, but now it works with an external buildConfigId as well: http://youtrack.jetbrains.com/issue/TW-32533

Let me know if there are any issues :)

/Regin
