### PR TITLE
BugFix

### DIFF
--- a/src/TeamCitySharp/Connection/TeamCityCaller.cs
+++ b/src/TeamCitySharp/Connection/TeamCityCaller.cs
@@ -67,6 +67,7 @@ namespace TeamCitySharp.Connection
                 throw new ArgumentException("If you are not acting as a guest you must supply userName and password");
             }
 
+            urlPart = System.Web.HttpUtility.UrlEncode(urlPart);
             if (string.IsNullOrEmpty(urlPart))
             {
                 throw new ArgumentException("Url must be specfied");


### PR DESCRIPTION
Make it possible to download artifacts, which include a "+" within the url. If the was an artifact containing e.g. a "+", the download was not working.
