### PR TITLE
Wire up the file entity to get the properties from the api's file object

### DIFF
--- a/src/TeamCitySharp/DomainEntities/File.cs
+++ b/src/TeamCitySharp/DomainEntities/File.cs
@@ -1,7 +1,16 @@
-﻿namespace TeamCitySharp.DomainEntities
+﻿using JsonFx.Json;
+
+namespace TeamCitySharp.DomainEntities
 {
     public class File
     {
-        public string relativefile { get; set; }
+        [JsonName("before-revision")] 
+        public string BeforeRevision { get; set; }
+        [JsonName("after-revision")] 
+        public string AfterRevision { get; set; }
+        [JsonName("relative-file")] 
+        public string RelativeFile { get; set; }
+
+        public string file { get; set; }
     }
 }


### PR DESCRIPTION
Wire up the file entity to get the properties from the api's file object 

Example returned -

```
<file before-revision="10844" after-revision="10845" file="http://myscmserver/somefile.txt" relative-file="somefile.txt"/>
```

Api version - TeamCity 8.1.2 (build 29993)
