### PR TITLE
Add 'changes since change id', fix compilation by adding System.Web

### DIFF
--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -2,5 +2,6 @@
 <repositories>
   <repository path="..\src\Samples\TeamCitySharp.BuildMonitor\packages.config" />
   <repository path="..\src\TeamCitySharp\packages.config" />
+  <repository path="..\src\Tests\IntegrationTests\packages.config" />
   <repository path="..\src\Tests\UnitTests\packages.config" />
 </repositories>

--- a/src/TeamCitySharp/ActionTypes/Builds.cs
+++ b/src/TeamCitySharp/ActionTypes/Builds.cs
@@ -16,6 +16,13 @@ namespace TeamCitySharp.ActionTypes
             _caller = caller;
         }
 
+		public Build ByBuildInternalId(string buildInternalId)
+		{
+			var build = _caller.GetFormat<Build>("/app/rest/builds/id:{0}", buildInternalId);
+
+			return build;
+		}
+
         public List<Build> ByBuildLocator(BuildLocator locator)
         {
             var buildWrapper = _caller.GetFormat<BuildWrapper>("/app/rest/builds?locator={0}", locator);

--- a/src/TeamCitySharp/ActionTypes/Changes.cs
+++ b/src/TeamCitySharp/ActionTypes/Changes.cs
@@ -31,14 +31,14 @@ namespace TeamCitySharp.ActionTypes
 
         public List<Change> ByBuildConfigId(string buildConfigId)
         {
-            var changeWrapper = _caller.GetFormat<ChangeWrapper>("/app/rest/changes?buildType={0}", buildConfigId);
+            var changeWrapper = _caller.GetFormat<ChangeWrapper>("/app/rest/changes?buildType=id:{0}", buildConfigId);
 
             return changeWrapper.Change;
         }
 
 		public List<Change> ByBuildConfigIdSinceChangeId(string buildConfigId, string sinceChangeId)
 		{
-			var changeWrapper = _caller.GetFormat<ChangeWrapper>("/app/rest/changes?buildType={0}&sinceChange=id:{1}", buildConfigId, sinceChangeId);
+			var changeWrapper = _caller.GetFormat<ChangeWrapper>("/app/rest/changes?buildType=id:{0}&sinceChange=id:{1}", buildConfigId, sinceChangeId);
 
 			return changeWrapper.Change;
 		}

--- a/src/TeamCitySharp/ActionTypes/Changes.cs
+++ b/src/TeamCitySharp/ActionTypes/Changes.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using TeamCitySharp.Connection;
 using TeamCitySharp.DomainEntities;
@@ -35,12 +36,18 @@ namespace TeamCitySharp.ActionTypes
             return changeWrapper.Change;
         }
 
+		public List<Change> ByBuildConfigIdSinceChangeId(string buildConfigId, string sinceChangeId)
+		{
+			var changeWrapper = _caller.GetFormat<ChangeWrapper>("/app/rest/changes?buildType={0}&sinceChange=id:{1}", buildConfigId, sinceChangeId);
+
+			return changeWrapper.Change;
+		}
+
         public Change LastChangeDetailByBuildConfigId(string buildConfigId)
         {
             var changes = ByBuildConfigId(buildConfigId);
 
             return changes.FirstOrDefault();
         }
-
     }
 }

--- a/src/TeamCitySharp/ActionTypes/IBuilds.cs
+++ b/src/TeamCitySharp/ActionTypes/IBuilds.cs
@@ -7,6 +7,7 @@ namespace TeamCitySharp.ActionTypes
 {
     public interface IBuilds
     {
+		Build ByBuildInternalId(string buildInternalId);
         List<Build> SuccessfulBuildsByBuildConfigId(string buildConfigId);
         Build LastSuccessfulBuildByBuildConfigId(string buildConfigId);
         List<Build> FailedBuildsByBuildConfigId(string buildConfigId);

--- a/src/TeamCitySharp/ActionTypes/IChanges.cs
+++ b/src/TeamCitySharp/ActionTypes/IChanges.cs
@@ -9,5 +9,6 @@ namespace TeamCitySharp.ActionTypes
         Change ByChangeId(string id);
         Change LastChangeDetailByBuildConfigId(string buildConfigId);
         List<Change> ByBuildConfigId(string buildConfigId);
+		List<Change> ByBuildConfigIdSinceChangeId(string buildConfigId, string sinceChangeId);
     }
 }

--- a/src/TeamCitySharp/DomainEntities/Build.cs
+++ b/src/TeamCitySharp/DomainEntities/Build.cs
@@ -16,7 +16,12 @@ namespace TeamCitySharp.DomainEntities
 
         public BuildConfig BuildConfig { get; set; }
         public Agent Agent { get; set;}
+
         public ChangeWrapper Changes { get; set; }
+		/// <summary>
+		/// TeamCity 8.* response to build queries fills changes in LastChanges.
+		/// </summary>
+		public ChangeWrapper LastChanges { get; set; }
 
         public override string ToString()
         {

--- a/src/TeamCitySharp/TeamCitySharp.csproj
+++ b/src/TeamCitySharp/TeamCitySharp.csproj
@@ -42,6 +42,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Tests/IntegrationTests/SampleBuildsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleBuildsUsage.cs
@@ -177,6 +177,19 @@ namespace TeamCitySharp.IntegrationTests
             Assert.IsNotNull(builds);
         }
 
+		[TestCase("bt5")]
+		public void it_returns_a_build_from_id(string buildConfigId)
+		{
+			var builds = _client.Builds.ByBuildConfigId(buildConfigId);
+
+			Assert.IsTrue(builds.Any(), "There are no builds from config id " + buildConfigId + ".  Cannot test retrieving one!");
+
+			var build = _client.Builds.ByBuildInternalId(builds.First().Id);
+
+			Assert.IsNotNull(build, "Did not return with a build!");
+			Assert.IsNotNullOrEmpty(build.Id, "Did not return with a build!");
+		}
+
         [Test]
         public void it_does_not_populate_the_status_text_field_of_the_build_object()
         {

--- a/src/Tests/IntegrationTests/SampleChangeUsage.cs
+++ b/src/Tests/IntegrationTests/SampleChangeUsage.cs
@@ -74,5 +74,13 @@ namespace TeamCitySharp.IntegrationTests
 
             Assert.That(changeDetails != null, "Cannot find details of that specified change");
         }
+
+		[TestCase("bt113", "42843")]
+		public void it_returns_change_details_since_build_id(string buildConfigId, string changeId)
+		{
+			List<Change> changes = _client.Changes.ByBuildConfigIdSinceChangeId(buildConfigId, changeId);
+
+			Assert.That(changes.Any(), "Cannot find any changes since the change id specified");
+		}
     }
 }

--- a/src/Tests/IntegrationTests/TeamCitySharp.IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/TeamCitySharp.IntegrationTests.csproj
@@ -78,6 +78,9 @@
       <Name>TeamCitySharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Tests/UnitTests/TeamCitySharp.UnitTests.csproj
+++ b/src/Tests/UnitTests/TeamCitySharp.UnitTests.csproj
@@ -61,6 +61,9 @@
       <Name>TeamCitySharp</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
- ByBuildConfigIdSinceChangeId() allows pulling Changes since a specified change id.  Useful to obtain the last successful change id and use that to find all changes SINCE that change id.
- Fixing build by adding System.Web to allow HttpUtility to be called.
