### PR TITLE
Implement statistics for builds

### DIFF
--- a/src/TeamCitySharp/ActionTypes/IStatistics.cs
+++ b/src/TeamCitySharp/ActionTypes/IStatistics.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using TeamCitySharp.DomainEntities;
+
+namespace TeamCitySharp.ActionTypes
+{
+    public interface IStatistics
+    {
+        List<Property> GetByBuildId(string buildId);
+    }
+}

--- a/src/TeamCitySharp/ActionTypes/Statistics.cs
+++ b/src/TeamCitySharp/ActionTypes/Statistics.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using TeamCitySharp.Connection;
+using TeamCitySharp.DomainEntities;
+
+namespace TeamCitySharp.ActionTypes
+{
+    public class Statistics : IStatistics
+    {
+        private readonly TeamCityCaller _caller;
+
+        internal Statistics(TeamCityCaller caller)
+        {
+            _caller = caller;
+        }
+
+        public List<Property> GetByBuildId(string buildId)
+        {
+            return _caller.GetFormat<Properties>("/app/rest/builds/id:{0}/statistics", buildId).Property;
+        }
+    }
+}

--- a/src/TeamCitySharp/ITeamCityClient.cs
+++ b/src/TeamCitySharp/ITeamCityClient.cs
@@ -17,5 +17,6 @@ namespace TeamCitySharp
         IVcsRoots VcsRoots { get; }
         IChanges Changes { get; }
         IBuildArtifacts Artifacts { get; }
+        IStatistics Statistics { get; }
     }
 }

--- a/src/TeamCitySharp/TeamCityClient.cs
+++ b/src/TeamCitySharp/TeamCityClient.cs
@@ -15,6 +15,7 @@ namespace TeamCitySharp
         private IVcsRoots _vcsRoots;
         private IChanges _changes;
         private IBuildArtifacts _artifacts;
+        private IStatistics _statistics;
 
         public TeamCityClient(string hostName, bool useSsl = false)
         {
@@ -79,6 +80,11 @@ namespace TeamCitySharp
         public IBuildArtifacts Artifacts
         {
             get { return _artifacts ?? (_artifacts = new BuildArtifacts(_caller)); }
+        }
+
+        public IStatistics Statistics
+        {
+            get { return _statistics ?? (_statistics = new Statistics(_caller)); }
         }
     }
 }

--- a/src/TeamCitySharp/TeamCitySharp.csproj
+++ b/src/TeamCitySharp/TeamCitySharp.csproj
@@ -42,6 +42,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -62,10 +63,12 @@
     <Compile Include="ActionTypes\IChanges.cs" />
     <Compile Include="ActionTypes\IProjects.cs" />
     <Compile Include="ActionTypes\IServerInformation.cs" />
+    <Compile Include="ActionTypes\IStatistics.cs" />
     <Compile Include="ActionTypes\IUsers.cs" />
     <Compile Include="ActionTypes\IVcsRoots.cs" />
     <Compile Include="ActionTypes\Projects.cs" />
     <Compile Include="ActionTypes\ServerInformation.cs" />
+    <Compile Include="ActionTypes\Statistics.cs" />
     <Compile Include="Connection\ITeamCityCaller.cs" />
     <Compile Include="TeamCityClient.cs" />
     <Compile Include="ActionTypes\Users.cs" />

--- a/src/Tests/IntegrationTests/SampleStatisticsUsage.cs
+++ b/src/Tests/IntegrationTests/SampleStatisticsUsage.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Net;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+using TeamCitySharp.DomainEntities;
+
+namespace TeamCitySharp.IntegrationTests
+{
+    [TestFixture]
+    public class when_interacting_to_get_build_statistics
+    {
+        private ITeamCityClient _client;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _client = new TeamCityClient("teamcity.codebetter.com");
+            _client.Connect("teamcitysharpuser", "qwerty");
+        }
+
+        [Test]
+        public void it_returns_no_of_tests_from_last_successful_build()
+        {
+            var proj = _client.Projects.ById("AutoFixture"); 
+            var build = _client.Builds.LastSuccessfulBuildByBuildConfigId(proj.BuildTypes.BuildType[0].Id);
+            var stats = _client.Statistics.GetByBuildId(build.Id);
+
+            Assert.That(stats.Any(property => property.Name.Equals("PassedTestCount")));
+        }
+   }
+}

--- a/src/Tests/IntegrationTests/TeamCitySharp.IntegrationTests.csproj
+++ b/src/Tests/IntegrationTests/TeamCitySharp.IntegrationTests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="SampleUserUsage.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="SampleStatisticsUsage.cs" />
     <Compile Include="SampleVcsUsage.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
Allows retrieval of properties such as no. of passed tests in a given
build. From
http://confluence.jetbrains.com/display/TCD8/REST+API#RESTAPI-Statistics

Sample integration tests see: src/Tests/IntegrationTests/SampleStatisticsUsage.cs
