### PR TITLE
Pin a Build by BuildConfigId and Build Number

### DIFF
--- a/src/TeamCitySharp/ActionTypes/Builds.cs
+++ b/src/TeamCitySharp/ActionTypes/Builds.cs
@@ -145,5 +145,11 @@ namespace TeamCitySharp.ActionTypes
 
             return builds.Where(b => b.Status != "SUCCESS").ToList();
         }
+
+        public void PinBuildByBuildNumber(string buildConfigId, string buildNumber, string message)
+        {
+            message = message == null ? string.Empty : message;
+            _caller.Put(message, "text/plain", string.Format("/app/rest/builds/buildType:{0},number:{1}/{2}/", buildConfigId, buildNumber, "pin"), null);
+        }
     }
 }

--- a/src/TeamCitySharp/ActionTypes/IBuilds.cs
+++ b/src/TeamCitySharp/ActionTypes/IBuilds.cs
@@ -24,5 +24,6 @@ namespace TeamCitySharp.ActionTypes
         List<Build> ByBranch(string branchName);
         Build LastBuildByAgent(string agentName);
         void Add2QueueBuildByBuildConfigId(string buildConfigId);
+        void PinBuildByBuildNumber(string buildConfigId, string buildNumber, string message);
     }
 }


### PR DESCRIPTION
Added a Function to Pin a Build by providing its BuildConfigId and
Buildnumber. A message string can be passed to the function, which will
show up as comment to the pinned build.

Revert "Pin a Build by ConfigId and BuildNumber"
