### PR TITLE
Added CreateConfigurationById

### DIFF
--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -2,5 +2,6 @@
 <repositories>
   <repository path="..\src\Samples\TeamCitySharp.BuildMonitor\packages.config" />
   <repository path="..\src\TeamCitySharp\packages.config" />
+  <repository path="..\src\Tests\IntegrationTests\packages.config" />
   <repository path="..\src\Tests\UnitTests\packages.config" />
 </repositories>

--- a/src/TeamCitySharp/ActionTypes/BuildConfigs.cs
+++ b/src/TeamCitySharp/ActionTypes/BuildConfigs.cs
@@ -80,9 +80,14 @@ namespace TeamCitySharp.ActionTypes
             return buildWrapper.BuildType;
         }
 
-        public BuildConfig CreateConfiguration(string projectName, string configurationName)
+        public BuildConfig CreateConfigurationByName(string projectName, string configurationName)
         {
             return _caller.PostFormat<BuildConfig>(configurationName, HttpContentTypes.TextPlain, HttpContentTypes.ApplicationJson, "/app/rest/projects/name:{0}/buildTypes", projectName);
+        }
+
+        public BuildConfig CreateConfigurationById(string projectId, string configurationName)
+        {
+            return _caller.PostFormat<BuildConfig>(configurationName, HttpContentTypes.TextPlain, HttpContentTypes.ApplicationJson, "/app/rest/projects/id:{0}/buildTypes", projectId);
         }
 
         public void SetConfigurationSetting(BuildTypeLocator locator, string settingName, string settingValue)

--- a/src/TeamCitySharp/ActionTypes/IBuildConfigs.cs
+++ b/src/TeamCitySharp/ActionTypes/IBuildConfigs.cs
@@ -17,7 +17,8 @@ namespace TeamCitySharp.ActionTypes
         BuildConfig ByProjectIdAndConfigurationId(string projectId, string buildConfigId);
         List<BuildConfig> ByProjectId(string projectId);
         List<BuildConfig> ByProjectName(string projectName);
-        BuildConfig CreateConfiguration(string projectName, string configurationName);
+        BuildConfig CreateConfigurationByName(string projectName, string configurationName);
+        BuildConfig CreateConfigurationById(string projectId, string configurationName);
 
         void SetConfigurationSetting(BuildTypeLocator locator, string settingName, string settingValue);
         bool GetConfigurationPauseStatus(BuildTypeLocator locator);
@@ -88,5 +89,6 @@ namespace TeamCitySharp.ActionTypes
         void PutAllBuildTypeParameters(BuildTypeLocator locator, IDictionary<string, string> parameters);
 
         void DownloadConfiguration(BuildTypeLocator locator, Action<string> downloadHandler);
+
     }
 }

--- a/src/TeamCitySharp/TeamCitySharp.csproj
+++ b/src/TeamCitySharp/TeamCitySharp.csproj
@@ -42,6 +42,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
This is needed if two projects have the same name but different parents.